### PR TITLE
Feature-#64: Add links to PR titles

### DIFF
--- a/reviews/controller.py
+++ b/reviews/controller.py
@@ -22,7 +22,9 @@ class PullRequestController:
         if not pull_requests:
             return None
 
-        return render_pull_request_table(title=title, pull_requests=pull_requests)
+        return render_pull_request_table(
+            title=title, pull_requests=pull_requests, org=org, repository=repository
+        )
 
     def update_pull_requests(self, org: str, repository: str) -> List[PullRequest]:
         """Updates repository models."""

--- a/reviews/layout/helpers.py
+++ b/reviews/layout/helpers.py
@@ -13,7 +13,9 @@ from rich.tree import Tree
 from reviews.datasource import PullRequest
 
 
-def render_pull_request_table(title: str, pull_requests: List[PullRequest]) -> Table:
+def render_pull_request_table(
+    title: str, pull_requests: List[PullRequest], org: str, repository: str
+) -> Table:
     """Renders a list of pull requests as a table"""
     table = Table(show_header=True, header_style="bold white")
     table.add_column("#", style="dim", width=5)
@@ -36,10 +38,12 @@ def render_pull_request_table(title: str, pull_requests: List[PullRequest]) -> T
         updated_at = f"{colour}{updated_at}"
 
         labels = ", ".join([label.name for label in pr.labels])
-
         table.add_row(
             f"[white]{pr.number} ",
-            f"[white]{pr.title}",
+            (
+                f"[white][link=https://www.github.com/"
+                f"{org}/{repository}/pull/{pr.number}]{pr.title}[/link]"
+            ),
             f"{labels}",
             f"{updated_at}",
             f"{approved}",


### PR DESCRIPTION
### What's Changed
Closes #64 

### Technical Description

- Edittted the function signature of ```render_pull_request_table``` such that org/repo information is available such that the 
link to PR can be formed.
- Added link to pr using f-strings

(It's my first time contributing to a project, and during testing I can't seem to be able to click onto anything from within the terminal -- is there a specific terminal that I need to use?)