### PR TITLE
[FEATURE-70] Adds functionality to perform a single render via `--no-reload`

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4,7 +4,7 @@ import asyncclick as click
 
 from create import prepare_database
 from reviews import config
-from reviews.tasks import render
+from reviews.tasks import render, single_render
 from reviews.version import __version__
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -17,7 +17,8 @@ async def main():
 
 
 @main.command(help="Display a dashboard")
-async def dashboard():
+@click.option("-r", "--reload/--no-reload", default=True, is_flag=True)
+async def dashboard(reload):
     """Dashboard command."""
 
     click.echo("loading dashboard")
@@ -25,11 +26,14 @@ async def dashboard():
     if config.ENABLE_PERSISTED_DATA:
         prepare_database()
 
-    # TODO: move github polling to another thread
-    await asyncio.gather(
-        # asyncio.to_thread(update),
-        asyncio.to_thread(render),
-    )
+    if reload:
+        # TODO: move github polling to another thread
+        await asyncio.gather(
+            # asyncio.to_thread(update),
+            asyncio.to_thread(render),
+        )
+    else:
+        single_render()
 
 
 if __name__ == "__main__":

--- a/reviews/layout/helpers.py
+++ b/reviews/layout/helpers.py
@@ -63,15 +63,15 @@ def render_pull_request_table(
     return table
 
 
-def generate_layout() -> Layout:
+def generate_layout(footer: bool = True) -> Layout:
     """Define the layout for the terminal UI."""
     layout = Layout(name="root")
 
-    layout.split(
-        Layout(name="header", size=3),
-        Layout(name="main", ratio=1),
-        Layout(name="footer", size=7),
-    )
+    sections = [Layout(name="header", size=3), Layout(name="main", ratio=1)]
+    if footer:
+        sections.append(Layout(name="footer", size=7))
+    layout.split(*sections)
+
     layout["main"].split_row(
         Layout(name="left_side", size=50),
         Layout(name="body", ratio=2, minimum_size=80),

--- a/reviews/layout/managers.py
+++ b/reviews/layout/managers.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from rich.console import Console, RenderGroup
 from rich.layout import Layout
 from rich.panel import Panel
@@ -16,17 +18,18 @@ class RenderLayoutManager:
 
     def render_layout(
         self,
-        progress_table: Table,
         body: Panel,
         pull_request_component: RenderGroup,
         log_component: Table,
+        progress_table: Optional[Table] = None,
     ) -> Layout:
         """Renders the entire layout"""
         self.render_header()
         self.render_body(component=body)
         self.render_log(component=log_component)
         self.render_configuration(component=pull_request_component)
-        self.render_footer(progress_table=progress_table)
+        if progress_table:
+            self.render_footer(progress_table=progress_table)
 
         return self.layout
 

--- a/reviews/tasks.py
+++ b/reviews/tasks.py
@@ -50,6 +50,29 @@ def _render_pull_requests(
     )
 
 
+def single_render() -> None:
+    """Renders the Terminal UI Dashboard once before closing the application"""
+
+    configuration = config.get_configuration()
+    controller = PullRequestController()
+
+    layout_manager = RenderLayoutManager(layout=generate_layout(footer=False))
+    layout_manager.render_layout(
+        progress_table=None,
+        body=_render_pull_requests(controller=controller, configuration=configuration),
+        pull_request_component=generate_tree_layout(configuration=configuration),
+        log_component=generate_log_table(logs=logs),
+    )
+
+    with Live(
+        renderable=layout_manager.layout,
+        refresh_per_second=5,
+        transient=False,
+        screen=False,
+    ):
+        add_log_event(message="updated")
+
+
 def render() -> None:
     """Renders Terminal UI Dashboard"""
     (
@@ -58,8 +81,6 @@ def render() -> None:
         overall_task,
         progress_table,
     ) = generate_progress_tracker()
-
-    # overall_progress = None
 
     # initial load should be from database
     add_log_event(message="initializing...")


### PR DESCRIPTION
### What's Changed

closes #70 and closes #76 if merged

adds function to perform a single UI render via `single_render` when `--no-reload` is provided. otherwise defaults to the continuous update-render cycle used in the `render` function.

### Technical Description

Adds a `single_render` function that removes the progress tracker and footer UI for progress tracking and only renders the output after data has been returned by Github

```bash
export REPOSITORY_CONFIGURATION="apoclyps/my-dev-space,apoclyps/reviews,apoclyps/magic-home"
```

```bash
python cli.py dashboard
python cli.py dashboard --reload
```

displays the following UI in a continuous loop

![image](https://user-images.githubusercontent.com/1443700/117062220-19974b80-ad1b-11eb-90ea-51738f4bd15f.png)

```bash
python cli.py dashboard --no-reload
```

displays the UI once before exiting the application.

![image](https://user-images.githubusercontent.com/1443700/117062502-67ac4f00-ad1b-11eb-815f-3f0cf226152d.png)
