### PR TITLE
[NO-TICKET] Adds github action to autoupdate pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,28 @@
+name: Pre-commit auto-update
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.CPR_GITHUB_TOKEN }}
+          branch: update/pre-commit-autoupdate
+          title: Auto-update pre-commit hooks
+          commit-message: Auto-update pre-commit hooks
+          body: Update versions of tools in pre-commit configs to latest version
+          labels: dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         args: [--safe, --quiet]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.1
+    rev: 3.9.2
     hooks:
       - id: flake8
 


### PR DESCRIPTION
### What's Changed

Adds a `pre-commit.yml` Github action to run daily at midnight to create a pull request containing any updates as a result of `pre-commit autoupdate`.

### Technical Description

As dependabot does not support bumping `pre-commit` see open issue https://github.com/dependabot/dependabot-core/issues/2040 , the following Github Action can be used instead: https://browniebroke.com/blog/gh-action-pre-commit-autoupdate/

Github action runs on a cron nightly to run `pre-commit autoupdate` which will open a pull request against the repository to update any out of date dependencies.