### PR TITLE
[NO-TICKET] upgrades create pull request action to v3

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,9 +18,10 @@ jobs:
       - name: Run pre-commit autoupdate
         run: pre-commit autoupdate
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.CPR_GITHUB_TOKEN }}
+          base: main
           branch: update/pre-commit-autoupdate
           title: Auto-update pre-commit hooks
           commit-message: Auto-update pre-commit hooks


### PR DESCRIPTION
### What's Changed

Updates create pull request action from v2 to v3

### Technical Description

updates to v3 using the documentation provided in ttps://github.com/peter-evans/create-pull-request. Also removes depreciation warnings caused by `add-path` or `set-env` in v2: see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/