### PR TITLE
FEATURE-85: Implemented coloured labels by config

### DIFF
--- a/reviews/config.py
+++ b/reviews/config.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 from decouple import Csv, config
+from rich.color import ANSI_COLOR_NAMES
 
 # Github Config
 GITHUB_TOKEN = config("GITHUB_TOKEN", cast=str, default="")
@@ -22,6 +23,11 @@ REPOSITORY_CONFIGURATION = config(
     cast=Csv(),
     default="apoclyps/reviews",
 )
+LABEL_CONFIGURATION = config(
+    "LABEL_CONFIGURATION",
+    cast=Csv(),
+    default="docker/purple,security/red,python/green",
+)
 
 
 def get_configuration() -> List[Tuple[str, str]]:
@@ -36,3 +42,18 @@ def get_configuration() -> List[Tuple[str, str]]:
         _to_tuple(values=configuration.split(sep="/", maxsplit=1))
         for configuration in REPOSITORY_CONFIGURATION
     ]
+
+
+def get_label_colour_map() -> Dict[str, str]:
+    """converts a comma seperated list of organizations/repositories into a list
+    of tuples.
+    """
+
+    def _preproc(label_colour: str) -> List[str]:
+        return label_colour.lower().split(sep="/")
+
+    return {
+        label: f"[{colour}]"
+        for label, colour in map(_preproc, LABEL_CONFIGURATION)
+        if colour in ANSI_COLOR_NAMES
+    }

--- a/reviews/layout/helpers.py
+++ b/reviews/layout/helpers.py
@@ -10,7 +10,12 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskID, TextColumn
 from rich.table import Table
 from rich.tree import Tree
 
+from reviews.config import get_label_colour_map
 from reviews.datasource import PullRequest
+
+
+def _colourise_label(label: str) -> str:
+    return get_label_colour_map().get(label.lower(), "[white]") + label
 
 
 def render_pull_request_table(
@@ -54,7 +59,7 @@ def render_pull_request_table(
         # format the ready to release status (approved by others)
         approved_by_others = "[green]Ready" if pr.approved_by_others else ""
 
-        labels = ", ".join([label.name for label in pr.labels])
+        labels = ", ".join([_colourise_label(label.name) for label in pr.labels])
 
         table.add_row(
             f"[white]{pr.number} ",


### PR DESCRIPTION
### What's Changed
Implemented feature to allow colouring of labels based on user config
Closes #85 

For ``export LABEL_CONFIGURATION="dependencies/cyan,docker/purple,security/yellow"``:
![image](https://user-images.githubusercontent.com/36848472/117858991-0a873f00-b2c1-11eb-96d0-ecf66c4e2bae.png)

For ``export LABEL_CONFIGURATION="dependencies/cyan,docker/purple,security/yellossw"`` (invalid colour):
![image](https://user-images.githubusercontent.com/36848472/117859104-2db1ee80-b2c1-11eb-88b2-f241e01a5c9a.png)

(Open to discussion here how to handle invalid colours provided by user)

### Technical Description

1.  New config ``LABEL_CONFIGURATION`` as discussed in #85
2. ``config.get_label_colour_map()`` - returns a dictionary containing a mapping of label  to colour
3. ``_colourise_label(label)`` helper function -- adds colour formatting to label if the label is in the user-specified / default label_colour_map -- otherwise it's formatted to be displayed in white.


