### PR TITLE
[NO-TICKET] adds visual identifier for draft PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9]
     defaults:
       run:
         shell: bash
@@ -42,6 +42,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          name: code_review_manager
+          name: reviews
           flags: unittests
           env_vars: OS,PYTHON

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/.pylintrc
+++ b/.pylintrc
@@ -151,6 +151,7 @@ disable=print-statement,
         global-statement,
         no-self-use,
         too-few-public-methods,
+        too-many-instance-attributes,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/reviews/config.py
+++ b/reviews/config.py
@@ -10,10 +10,8 @@ GITHUB_USER = config("GITHUB_USER", cast=str, default="")
 DEFAULT_PAGE_SIZE = config("DEFAULT_PAGE_SIZE", cast=int, default=100)
 
 # Database Config
-DATA_PATH = config(
-    "DATA_PATH", cast=str, default=f"{str(Path.home())}/.code_review_manager"
-)
-FILENAME = config("FILENAME", cast=str, default="code_review_manager.db")
+DATA_PATH = config("DATA_PATH", cast=str, default=f"{str(Path.home())}/.reviews")
+FILENAME = config("FILENAME", cast=str, default="reviews.db")
 
 # Application Config
 DELAY_REFRESH = config("DELAY_REFRESH", cast=int, default=60)
@@ -26,7 +24,7 @@ REPOSITORY_CONFIGURATION = config(
 LABEL_CONFIGURATION = config(
     "LABEL_CONFIGURATION",
     cast=Csv(),
-    default="docker/purple,security/red,python/green",
+    default="blocked/orange,docker/blue,security/red,python/green",
 )
 
 

--- a/reviews/controller.py
+++ b/reviews/controller.py
@@ -38,6 +38,7 @@ class PullRequestController:
             """Inner function to retrieve reviews for a pull request"""
             reviews = pull_request.get_reviews()
             res, seen = {}, []
+
             for review in reviews:
                 if review.user.login in seen or review.state == "COMMENTED":
                     continue
@@ -46,10 +47,12 @@ class PullRequestController:
             return res
 
         pull_requests = self.client.get_pull_requests(org=org, repo=repository)
+
         return [
             PullRequest(
                 number=pull_request.number,
                 title=pull_request.title,
+                draft=pull_request.draft,
                 created_at=pull_request.created_at,
                 updated_at=pull_request.updated_at,
                 approved=_get_reviews(pull_request=pull_request).get(

--- a/reviews/datasource/models.py
+++ b/reviews/datasource/models.py
@@ -16,6 +16,7 @@ class PullRequest:
 
     number: int
     title: str
+    draft: bool
     created_at: datetime
     updated_at: datetime
     approved: str

--- a/reviews/layout/helpers.py
+++ b/reviews/layout/helpers.py
@@ -25,20 +25,24 @@ def render_pull_request_table(
     table = Table(show_header=True, header_style="bold white")
     table.add_column("#", style="dim", width=5)
     table.add_column(
-        f"[link=https://www.github.com/{org}/{repository}]{title}[/link]", width=60
+        f"[link=https://www.github.com/{org}/{repository}]{title}[/link]", width=75
     )
     table.add_column("Labels", width=40)
     table.add_column("Activity", width=15)
-    table.add_column("Approved", width=15)
-    table.add_column("Ready To Release", width=10)
+    table.add_column("Approved", width=10)
+    table.add_column("Mergeable", width=10)
 
     pull_requests = sorted(pull_requests, key=lambda x: x.updated_at, reverse=True)
 
     for pr in pull_requests:
         # format and colourize pull request title
-        title_colour = "[white]"
-        if "Security" in pr.title:
-            title_colour = "[red]"
+
+        title_colour = ""
+        if pr.title.startswith("[Security]"):
+            pr.title = pr.title.removeprefix("[Security]")
+            title_colour = "[bold red][Security][/]"
+        if pr.draft:
+            title_colour = "[bold grey][Draft] [/]"
 
         # format pull request last modified at datetime as a human-readable time
         updated_at = humanize.naturaltime(pr.updated_at)
@@ -52,20 +56,20 @@ def render_pull_request_table(
         # formats the approval status (approved by me)
         approved = ""
         if pr.approved == "APPROVED":
-            approved = "[green]Approved"
+            approved = "[green]Approved[/]"
         elif pr.approved == "CHANGES_REQUESTED":
-            approved = "[red]Changes Requested"
+            approved = "[red]Changes Requested[/]"
 
         # format the ready to release status (approved by others)
-        approved_by_others = "[green]Ready" if pr.approved_by_others else ""
+        approved_by_others = "[green]Ready[/]" if pr.approved_by_others else ""
 
         labels = ", ".join([_colourise_label(label.name) for label in pr.labels])
 
         table.add_row(
             f"[white]{pr.number} ",
             (
-                f"{title_colour}[link=https://www.github.com/"
-                f"{org}/{repository}/pull/{pr.number}]{pr.title}[/link]"
+                f"{title_colour}[white][link=https://www.github.com/"
+                f"{org}/{repository}/pull/{pr.number}]{pr.title}[/link][/]"
             ),
             f"{labels}",
             f"{updated_at}",
@@ -86,8 +90,8 @@ def generate_layout(footer: bool = True) -> Layout:
     layout.split(*sections)
 
     layout["main"].split_row(
-        Layout(name="left_side", size=50),
-        Layout(name="body", ratio=2, minimum_size=80),
+        Layout(name="left_side", size=40),
+        Layout(name="body", ratio=2, minimum_size=90),
     )
     layout["left_side"].split(Layout(name="configuration"), Layout(name="log"))
     return layout

--- a/reviews/tasks.py
+++ b/reviews/tasks.py
@@ -55,10 +55,12 @@ def single_render() -> None:
     configuration = config.get_configuration()
     controller = PullRequestController()
 
+    body = _render_pull_requests(controller=controller, configuration=configuration)
+
     layout_manager = RenderLayoutManager(layout=generate_layout(footer=False))
     layout_manager.render_layout(
         progress_table=None,
-        body=_render_pull_requests(controller=controller, configuration=configuration),
+        body=body,
         pull_request_component=generate_tree_layout(configuration=configuration),
         log_component=generate_log_table(logs=logs),
     )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/apoclyps/reviews",
-    download_url="https://github.com/apoclyps/reviews/archive/0.1.0.tar.gz",
+    download_url="https://pypi.org/project/reviews/",
     keywords=["Reviews", "pull request review"],
     install_requires=_requires_from_file("requirements.txt"),
     entry_points={"console_scripts": ["reviews = cli:main"]},

--- a/tests/datasource/test_client.py
+++ b/tests/datasource/test_client.py
@@ -21,6 +21,7 @@ def manager(setup_database):
 def pull_request():
     return PullRequest(
         number=1,
+        draft=False,
         title="[1] Initial Commit",
         created_at=datetime.now(),
         updated_at=datetime.now(),
@@ -59,6 +60,7 @@ def test_bulk_insert(manager):
         models=[
             PullRequest(
                 number=1,
+                draft=False,
                 title="[1] Initial Commit",
                 created_at=datetime.now(),
                 updated_at=datetime.now(),
@@ -68,6 +70,7 @@ def test_bulk_insert(manager):
             ),
             PullRequest(
                 number=2,
+                draft=True,
                 title="[2] Adds README",
                 created_at=datetime.now(),
                 updated_at=datetime.now(),


### PR DESCRIPTION
### What's Changed

Adds a visual identifier for draft pull requests.

![image](https://user-images.githubusercontent.com/1443700/118355415-d1242d00-b567-11eb-936e-6befce05387e.png)

### Technical Description

Draft pull requests are prefixed with `[Draft] ` and are now coloured grey - instead of white. 
