### PR TITLE
[FEATURE-119] Adds support for Github Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ reviews dashboard --no-reload
 
 [![asciicast](https://asciinema.org/a/LEs7tltVE3guhsLEEFGc5FDiD.svg)](https://asciinema.org/a/LEs7tltVE3guhsLEEFGc5FDiD)
 
+### Addtional Support
+
+If you wish to use Reviews with a Github Enterprise instead of Github (https://api.github.com", you can set the `GITHUB_URL` with your custom hostname. You will also need to ensure your `GITHUB_USER` and `GITHUB_TOKEN` exist within your Enterprise Github instance:
+
+```bash
+export GITHUB_URL=https://{hostname}/api/v3
+export GITHUB_USER=user
+export GITHUB_TOKEN=token
+```
+
+
 ### Getting started with local development
 
 To build and run the CLI on your host, you will need Python 3.9, pip, and virtualenv to build and run `review`:
@@ -100,6 +111,6 @@ the pre-commit pipeline can be set up by running the following command on the pr
 pre-commit install
 ```
 
-# Contributions
+### Contributions
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.

--- a/reviews/config.py
+++ b/reviews/config.py
@@ -7,6 +7,7 @@ from rich.color import ANSI_COLOR_NAMES
 # Github Config
 GITHUB_TOKEN = config("GITHUB_TOKEN", cast=str, default="")
 GITHUB_USER = config("GITHUB_USER", cast=str, default="")
+GITHUB_URL = config("GITHUB_URL", cast=str, default="https://api.github.com")
 DEFAULT_PAGE_SIZE = config("DEFAULT_PAGE_SIZE", cast=int, default=100)
 
 # Database Config

--- a/reviews/source_control/client.py
+++ b/reviews/source_control/client.py
@@ -11,7 +11,11 @@ class GithubAPI:
     """Create and execute requests using the Github API"""
 
     def __init__(self) -> None:
-        self._client = Github(config.GITHUB_TOKEN, per_page=config.DEFAULT_PAGE_SIZE)
+        self._client = Github(
+            config.GITHUB_TOKEN,
+            per_page=config.DEFAULT_PAGE_SIZE,
+            base_url=config.GITHUB_URL,
+        )
 
     def get_repository(self, org: str, repo: str) -> Repository:
         """Returns a repository for a given organization."""


### PR DESCRIPTION
### What's Changed

Adds support for Github Enterprise

implements #119 

### Technical Description

Allows the `base_url` of the Github client to be configured using the `GITHUB_USER` environmental variable. 

Defaults to `"https://api.github.com"` when not set - otherwise can be overridden to allow for users to specify their custom hostname for usage with Github Enterprise. 

