### PR TITLE
[FEATURE-122] Adds inline diff counts for pull requests

### DIFF
--- a/reviews/controller.py
+++ b/reviews/controller.py
@@ -52,6 +52,8 @@ class PullRequestController:
                 number=pull_request.number,
                 title=pull_request.title,
                 draft=pull_request.draft,
+                additions=pull_request.additions,
+                deletions=pull_request.deletions,
                 created_at=pull_request.created_at,
                 updated_at=pull_request.updated_at,
                 approved=_get_reviews(pull_request=pull_request).get(

--- a/reviews/layout/helpers.py
+++ b/reviews/layout/helpers.py
@@ -26,7 +26,8 @@ def render_pull_request_table(
         f"[link=https://www.github.com/{org}/{repository}]{title}[/link]",
         width=75,
     )
-    table.add_column("Labels", width=40)
+    table.add_column("Labels", width=30)
+    table.add_column("Diff +/-", width=10)
     table.add_column("Activity", width=15)
     table.add_column("Approved", width=10)
     table.add_column("Mergeable", width=10)
@@ -38,6 +39,7 @@ def render_pull_request_table(
             f"[white]{pr.number} ",
             pr.render_title(org, repository),
             pr.render_labels(label_colour_map),
+            pr.render_diff(),
             pr.render_updated_at(),
             pr.render_approved(),
             pr.render_approved_by_others(),
@@ -55,7 +57,7 @@ def generate_layout(log: bool = True, footer: bool = True) -> Layout:
         sections.append(Layout(name="footer", size=7))
     layout.split(*sections)
 
-    layout["main"].split_row(
+    layout["main"].split_row(  # type: ignore
         Layout(name="left_side", size=40),
         Layout(name="body", ratio=2, minimum_size=90),
     )

--- a/reviews/source_control/models.py
+++ b/reviews/source_control/models.py
@@ -23,6 +23,8 @@ class PullRequest:
     updated_at: datetime
     approved: str
     approved_by_others: bool
+    additions: int = 0
+    deletions: int = 0
     labels: List[Label] = field(default_factory=list)
 
     def render_approved(self) -> str:
@@ -78,3 +80,7 @@ class PullRequest:
             suffix = "[/]"
 
         return f"{colour}{humanize.naturaltime(self.updated_at, when=since)}{suffix}"
+
+    def render_diff(self) -> str:
+        """Renders the additions and deletions using the Github convention of +/-"""
+        return f"[green]+{self.additions}[/green] [red]-{self.deletions}[/red]"


### PR DESCRIPTION
### What's Changed

Adds a `Diff` colour to show the additions and deletions for a pull request.

implements #122

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/1443700/118724470-900d7080-b826-11eb-9024-4b48c0c51ff2.png) | ![image](https://user-images.githubusercontent.com/1443700/118724644-c2b76900-b826-11eb-9310-abecef7da3fc.png) |



### Technical Description

Adds `additions` and `deletions` to PullRequest model (with a default of 0)  and renders diff inline for each pull request.