### PR TITLE
[FEATURE-79] Identify pull requests created by the author

### DIFF
--- a/reviews/source_control/models.py
+++ b/reviews/source_control/models.py
@@ -29,11 +29,16 @@ class PullRequest:
 
     def render_approved(self) -> str:
         """Renders the approved status as a colourised string"""
-        if self.approved == "APPROVED":
-            return "[green]Approved[/]"
-        if self.approved == "CHANGES_REQUESTED":
-            return "[red]Changes Requested[/]"
-        return ""
+        status = ""
+
+        if self.approved == "AUTHOR":
+            status = "[grey]Author[/]"
+        elif self.approved == "APPROVED":
+            status = "[green]Approved[/]"
+        elif self.approved == "CHANGES_REQUESTED":
+            status = "[red]Changes Requested[/]"
+
+        return status
 
     def render_approved_by_others(self) -> str:
         """Renders approved_by_others flag as a colourised string"""


### PR DESCRIPTION
### What's Changed

Allows pull requests created by the author to be identified uniquely in the dashboard

![image](https://user-images.githubusercontent.com/1443700/118886425-d5967000-b8f0-11eb-9092-9af090fb4d70.png)

closes #79 

### Technical Description

When the `GITHUB_USER` is provided, we can compare it against the user on the pull request. If it's a match, we now show the approval status as a greyed out label saying `Author` to identify that the user does not need to approve their own pull request.

