### PR TITLE
[BUG] Fix installation setup to avoid no module named cli errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ ENV/
 # editors
 .vscode/*
 .idea/*
+
+# mypy
+.mypy_cache/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ python3 -m venv env
 $ source env/bin/activate
 (env)$ pip install -r requirements_dev.txt
 (env)$ pip install -r requirements.txt
-(env)$ python cli.py dashboard
+(env)$ python -m reviews dashboard
 ```
 
 If you wish to keep a copy of Reviews on your host system, you can install and run it using:
@@ -54,21 +54,20 @@ $ export REPOSITORY_CONFIGURATION="apoclyps/reviews"
 $ python -m venv env
 $ source env/bin/activate
 $ python -m pip install -e .
-$ command -v reviews
 $ reviews -h
 ```
 
 You can run the Reviews within Docker:
 
 ```bash
-docker-compose build cli && docker-compose run --rm cli python cli.py dashboard
+docker-compose build cli && docker-compose run --rm cli python -m reviews dashboard
 ```
 
 To build an image and run that image with all of the necessary dependencies using the following commands:
 
 ```bash
 $ docker-compose build cli
-$ docker-compose run --rm cli python cli.py dashboard
+$ docker-compose run --rm cli python -m reviews dashboard
 ```
 
 For instructions on setting up a development enviroment outside of Docker, checkout the [wiki](https://github.com/apoclyps/reviews/wiki/Development-Enviromnent).

--- a/README.md
+++ b/README.md
@@ -47,12 +47,15 @@ $ source env/bin/activate
 (env)$ python cli.py dashboard
 ```
 
-If you wish to keep a copy of Reviews on your host system forever, you can install and run it using:
+If you wish to keep a copy of Reviews on your host system, you can install and run it using:
 
 ```bash
 $ export REPOSITORY_CONFIGURATION="apoclyps/reviews"
-$ pip install -e .
-$ reviews dashboard
+$ python -m venv env
+$ source env/bin/activate
+$ python -m pip install -e .
+$ command -v reviews
+$ reviews -h
 ```
 
 You can run the Reviews within Docker:

--- a/cli-runner.py
+++ b/cli-runner.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from reviews.cli.main import main
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   cli: &cli
     build: .
-    command: python cli.py dashboard
+    command: python -m reviews dashboard
     working_dir: /usr/src/app/
     environment:
       - DEBUG=true

--- a/reviews/__main__.py
+++ b/reviews/__main__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""Reviews CLI - Main script."""
+
+from .cli.main import main
+
+if __name__ == "__main__":
+    main()

--- a/reviews/cli/main.py
+++ b/reviews/cli/main.py
@@ -2,24 +2,24 @@ import asyncio
 
 import asyncclick as click
 
-from reviews.tasks import render, single_render
-from reviews.version import __version__
+from ..tasks import render, single_render
+from ..version import __version__
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.version_option(__version__, "-v", "--version", message="version %(version)s")
-async def main():
+async def cli() -> None:
     """Reviews - A terminal UI Dashboard for monitoring code review requests.\n
 
     For feature requests or bug reports: https://github.com/apoclyps/reviews/issues
     """
 
 
-@main.command(help="Visualize code review requests as a Dashboard")
+@cli.command(help="Visualize code review requests as a Dashboard")
 @click.option("-r", "--reload/--no-reload", default=True, is_flag=True)
-async def dashboard(reload):
+async def dashboard(reload: bool) -> None:
     """
     Command:\n
         reviews dashboard
@@ -40,5 +40,6 @@ async def dashboard(reload):
         single_render()
 
 
-if __name__ == "__main__":
-    asyncio.run(main())
+def main() -> None:
+    """Entry point to CLI"""
+    asyncio.run(cli())

--- a/reviews/controller.py
+++ b/reviews/controller.py
@@ -3,9 +3,9 @@ from typing import Dict, List, Union
 from github.PullRequest import PullRequest as ghPullRequest
 from rich.table import Table
 
-from reviews import config
-from reviews.layout import render_pull_request_table
-from reviews.source_control import GithubAPI, Label, PullRequest
+from . import config
+from .layout import render_pull_request_table
+from .source_control import GithubAPI, Label, PullRequest
 
 
 class PullRequestController:

--- a/reviews/layout/__init__.py
+++ b/reviews/layout/__init__.py
@@ -1,8 +1,8 @@
-from reviews.layout.helpers import (  # NOQA: F401
+from ..layout.helpers import (  # NOQA: F401
     generate_layout,
     generate_log_table,
     generate_progress_tracker,
     generate_tree_layout,
     render_pull_request_table,
 )
-from reviews.layout.managers import RenderLayoutManager  # NOQA: F401
+from ..layout.managers import RenderLayoutManager  # NOQA: F401

--- a/reviews/layout/helpers.py
+++ b/reviews/layout/helpers.py
@@ -9,8 +9,8 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskID, TextColumn
 from rich.table import Table
 from rich.tree import Tree
 
-from reviews.config import get_label_colour_map
-from reviews.source_control import PullRequest
+from ..config import get_label_colour_map
+from ..source_control import PullRequest
 
 
 def render_pull_request_table(

--- a/reviews/layout/managers.py
+++ b/reviews/layout/managers.py
@@ -5,7 +5,7 @@ from rich.layout import Layout
 from rich.panel import Panel
 from rich.table import Table
 
-from reviews.layout.components import Header
+from ..layout.components import Header
 
 console = Console()
 

--- a/reviews/source_control/__init__.py
+++ b/reviews/source_control/__init__.py
@@ -1,2 +1,2 @@
-from reviews.source_control.client import GithubAPI  # NOQA: F401
-from reviews.source_control.models import Label, PullRequest  # NOQA: F401
+from ..source_control.client import GithubAPI  # NOQA: F401
+from ..source_control.models import Label, PullRequest  # NOQA: F401

--- a/reviews/source_control/client.py
+++ b/reviews/source_control/client.py
@@ -4,7 +4,7 @@ from github import Github
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
-from reviews import config
+from .. import config
 
 
 class GithubAPI:

--- a/reviews/tasks.py
+++ b/reviews/tasks.py
@@ -7,9 +7,9 @@ from rich.console import RenderGroup
 from rich.live import Live
 from rich.panel import Panel
 
-from reviews import config
-from reviews.controller import PullRequestController
-from reviews.layout import (
+from . import config
+from .controller import PullRequestController
+from .layout import (
     RenderLayoutManager,
     generate_layout,
     generate_log_table,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="reviews",
-    packages=find_namespace_packages(include=["reviews.*"]),
+    packages=find_namespace_packages(include=["*"]),
     version="0.1.7",
     license="MIT",
     description=(
@@ -26,7 +26,7 @@ setup(
     download_url="https://pypi.org/project/reviews/",
     keywords=["Reviews", "pull request review"],
     install_requires=_requires_from_file("requirements.txt"),
-    entry_points={"console_scripts": ["reviews = cli:main"]},
+    entry_points={"console_scripts": ["reviews = reviews.cli.main:main"]},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Console",

--- a/tests/source_control/models/test_pull_request.py
+++ b/tests/source_control/models/test_pull_request.py
@@ -4,7 +4,7 @@ from typing import Dict
 import pytest
 from freezegun import freeze_time
 
-from reviews.source_control import PullRequest, Label
+from .source_control import PullRequest, Label
 
 
 @pytest.fixture

--- a/tests/source_control/models/test_pull_request.py
+++ b/tests/source_control/models/test_pull_request.py
@@ -4,7 +4,7 @@ from typing import Dict
 import pytest
 from freezegun import freeze_time
 
-from .source_control import PullRequest, Label
+from reviews.source_control import PullRequest, Label
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ import os
 
 from decouple import Csv, config
 
-from . import config as application_config
+from reviews import config as application_config
 
 
 def test_repository_configuration():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ import os
 
 from decouple import Csv, config
 
-from reviews import config as application_config
+from . import config as application_config
 
 
 def test_repository_configuration():


### PR DESCRIPTION
### What's Changed

Fix for https://github.com/apoclyps/reviews/issues/41

### Technical Description

Converts module to use relative imports and adds `__main__.py`, and `reviews/cli/main.py` to ensure the module builds and run successfully. 

### Steps to test

```bash
# from the root of the checked out repository ~/workspace/reviews
python -m reviews -h
```

```bash
# from the root of the checked out repository ~/workspace/reviews
./cli-runner.py
```

```bash
# from the root of the checked out repository ~/workspace/reviews
python -m venv env
source env/bin/activate
python -m pip install -e .
command -v reviews
reviews -h
```

```bash
# from the root of the checked out repository ~/workspace/reviews
python -m venv env
source env/bin/activate
python -m pip install .
cd /tmp/
/path/to/repo/env/bin/reviews -h
```
