### PR TITLE
[BUG] Replaces asyncclick with click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asyncclick==7.1.2.3
+click==8.0.1
 humanize==3.5.0
 keyboard==0.13.5
 PyGithub==1.55

--- a/reviews/cli/main.py
+++ b/reviews/cli/main.py
@@ -1,6 +1,4 @@
-import asyncio
-
-import asyncclick as click
+import click
 
 from ..tasks import render, single_render
 from ..version import __version__
@@ -10,7 +8,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.version_option(__version__, "-v", "--version", message="version %(version)s")
-async def cli() -> None:
+def cli() -> None:
     """Reviews - A terminal UI Dashboard for monitoring code review requests.\n
 
     For feature requests or bug reports: https://github.com/apoclyps/reviews/issues
@@ -19,7 +17,7 @@ async def cli() -> None:
 
 @cli.command(help="Visualize code review requests as a Dashboard")
 @click.option("-r", "--reload/--no-reload", default=True, is_flag=True)
-async def dashboard(reload: bool) -> None:
+def dashboard(reload: bool) -> None:
     """
     Command:\n
         reviews dashboard
@@ -32,14 +30,11 @@ async def dashboard(reload: bool) -> None:
     click.echo("loading dashboard")
 
     if reload:
-        await asyncio.gather(
-            # asyncio.to_thread(update),
-            asyncio.to_thread(render),
-        )
+        render()
     else:
         single_render()
 
 
 def main() -> None:
     """Entry point to CLI"""
-    asyncio.run(cli())
+    cli()

--- a/reviews/tasks.py
+++ b/reviews/tasks.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import datetime
 from time import sleep
 from typing import List, Tuple
@@ -138,11 +137,3 @@ def render() -> None:
                 overall_progress.update(overall_task, completed=completed)
 
             add_log_event(message="updated")
-
-
-async def update() -> None:
-    """Updates data in the background."""
-
-    while True:
-        print("working")
-        await asyncio.sleep(1)


### PR DESCRIPTION
### What's Changed

Following the removal of #95 and #109, `reviews` no longer need to use async. This also resolves a bug where exiting reviews was difficult due to a blocking call. 

[![asciicast](https://asciinema.org/a/Iinam0pEiJgkrZeXiUQdefPSZ.svg)](https://asciinema.org/a/Iinam0pEiJgkrZeXiUQdefPSZ)

resolves #130 

closes #129 

### Technical Description

This PR removes asyncclick and upgrades to click==8.0.1: https://pypi.org/project/click/