### PR TITLE
[FEATURE-102] adds config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ export REPOSITORY_CONFIGURATION="apoclyps/reviews"
 
 pip install --upgrade reviews
 
+reviews config --show
+
 reviews dashboard --no-reload
 ```
 
@@ -34,6 +36,13 @@ export GITHUB_USER=user
 export GITHUB_TOKEN=token
 ```
 
+If you wish to view the configuration used by reviews at any time, you can use the following command to show all configuration (with secerts hidden or shown):
+
+```bash
+reviews config --hide
+
+reviews config --show
+```
 
 ### Getting started with local development
 

--- a/reviews/cli/main.py
+++ b/reviews/cli/main.py
@@ -1,6 +1,6 @@
 import click
 
-from ..tasks import render, single_render
+from ..tasks import render, render_config, single_render
 from ..version import __version__
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -13,6 +13,20 @@ def cli() -> None:
 
     For feature requests or bug reports: https://github.com/apoclyps/reviews/issues
     """
+
+
+@cli.command(help="Show the current configuration used by Reviews")
+@click.option("-show", "--show/--hide", default=False, is_flag=True)
+def config(show: bool) -> None:
+    """
+    Command:\n
+        reviews config
+
+    Usage:\n
+        reviews config --show \n
+        reviews config --hide \n
+    """
+    render_config(show=show)
 
 
 @cli.command(help="Visualize code review requests as a Dashboard")

--- a/reviews/config/__init__.py
+++ b/reviews/config/__init__.py
@@ -1,0 +1,12 @@
+from ..config.render import render_config_table  # NOQA: F401
+from ..config.settings import (  # NOQA: F401
+    DEFAULT_PAGE_SIZE,
+    DELAY_REFRESH,
+    GITHUB_TOKEN,
+    GITHUB_URL,
+    GITHUB_USER,
+    LABEL_CONFIGURATION,
+    REPOSITORY_CONFIGURATION,
+    get_configuration,
+    get_label_colour_map,
+)

--- a/reviews/config/render.py
+++ b/reviews/config/render.py
@@ -1,0 +1,17 @@
+from typing import Dict, List
+
+from rich.console import Console
+from rich.table import Table
+
+
+def render_config_table(configurations: List[Dict[str, str]]) -> None:
+    """Renders a table using the supplied configuration."""
+    table = Table()
+    table.add_column("Name", style="white", no_wrap=True)
+    table.add_column("Value", style="cyan")
+
+    for configuration in configurations:
+        table.add_row(configuration["name"], configuration["value"])
+
+    console = Console()
+    console.print(table)

--- a/reviews/config/settings.py
+++ b/reviews/config/settings.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Dict, List, Tuple
 
 from decouple import Csv, config
@@ -10,13 +9,8 @@ GITHUB_USER = config("GITHUB_USER", cast=str, default="")
 GITHUB_URL = config("GITHUB_URL", cast=str, default="https://api.github.com")
 DEFAULT_PAGE_SIZE = config("DEFAULT_PAGE_SIZE", cast=int, default=100)
 
-# Database Config
-DATA_PATH = config("DATA_PATH", cast=str, default=f"{str(Path.home())}/.reviews")
-FILENAME = config("FILENAME", cast=str, default="reviews.db")
-
 # Application Config
 DELAY_REFRESH = config("DELAY_REFRESH", cast=int, default=60)
-ENABLE_PERSISTED_DATA = config("ENABLE_PERSISTED_DATA", cast=bool, default=False)
 REPOSITORY_CONFIGURATION = config(
     "REPOSITORY_CONFIGURATION",
     cast=Csv(),

--- a/reviews/tasks.py
+++ b/reviews/tasks.py
@@ -7,6 +7,7 @@ from rich.live import Live
 from rich.panel import Panel
 
 from . import config
+from .config import render_config_table
 from .controller import PullRequestController
 from .layout import (
     RenderLayoutManager,
@@ -137,3 +138,26 @@ def render() -> None:
                 overall_progress.update(overall_task, completed=completed)
 
             add_log_event(message="updated")
+
+
+def render_config(show: bool) -> None:
+    """Renders a table displaying configuration used by Reviews."""
+    configurations = [
+        {
+            "name": "GITHUB_TOKEN",
+            "value": config.GITHUB_TOKEN
+            if show
+            else "".join("*" for _ in range(0, len(config.GITHUB_TOKEN))),
+        },
+        {"name": "GITHUB_USER", "value": config.GITHUB_USER},
+        {"name": "GITHUB_URL", "value": config.GITHUB_URL},
+        {"name": "DEFAULT_PAGE_SIZE", "value": f"{config.DEFAULT_PAGE_SIZE}"},
+        {"name": "DELAY_REFRESH", "value": f"{config.DELAY_REFRESH}"},
+        {
+            "name": "REPOSITORY_CONFIGURATION",
+            "value": ", ".join(config.REPOSITORY_CONFIGURATION),
+        },
+        {"name": "LABEL_CONFIGURATION", "value": ", ".join(config.LABEL_CONFIGURATION)},
+    ]
+
+    render_config_table(configurations=configurations)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,23 +1,13 @@
 import os
+from unittest import mock
 
-from decouple import Csv, config
-
-from reviews import config as application_config
+from reviews import config
 
 
+@mock.patch.dict(os.environ, {"REPOSITORY_CONFIGURATION": "apoclyps/reviews"})
 def test_repository_configuration():
-    os.environ[
-        "REPOSITORY_CONFIGURATION"
-    ] = "apoclyps/reviews, apoclyps/my-dev-space, apoclyps/magic-home"
-
-    application_config.REPOSITORY_CONFIGURATION = config(
-        "REPOSITORY_CONFIGURATION",
-        cast=Csv(),
-    )
-    configuration = application_config.get_configuration()
+    configuration = config.get_configuration()
 
     assert configuration == [
         ("apoclyps", "reviews"),
-        ("apoclyps", "my-dev-space"),
-        ("apoclyps", "magic-home"),
     ]


### PR DESCRIPTION
### What's Changed

Adds a `config` command to show all configuration used by reviews - with secrets hidden by default.

![image](https://user-images.githubusercontent.com/1443700/120103032-931d3080-c145-11eb-831e-d56ba004909c.png)

implements #102 

### Technical Description

Allows configuration used by `reviews` to be viewed.

```bash
reviews config --hide

reviews config --show
```