### PR TITLE
[FEATURE-115] adds PATH_TO_CONFIG env var to provide configuration outside of module/repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you want to get up and running with Reviews immediately, run:
 
 ```bash
 export GITHUB_USER="your-github-username"
-export GITHUB_TOKEN="your personal github token used for interacting with the API"
+export GITHUB_TOKEN="your personal GitHub token used for interacting with the API"
 export REPOSITORY_CONFIGURATION="apoclyps/reviews"
 
 pip install --upgrade reviews
@@ -36,7 +36,7 @@ export GITHUB_USER=user
 export GITHUB_TOKEN=token
 ```
 
-If you wish to view the configuration used by reviews at any time, you can use the following command to show all configuration (with secerts hidden or shown):
+If you wish to view the configuration used by reviews at any time, you can use the following command to show all configuration (with secrets hidden or shown):
 
 ```bash
 reviews config --hide
@@ -79,11 +79,46 @@ $ docker-compose build cli
 $ docker-compose run --rm cli python -m reviews dashboard
 ```
 
-For instructions on setting up a development enviroment outside of Docker, checkout the [wiki](https://github.com/apoclyps/reviews/wiki/Development-Enviromnent).
+For instructions on setting up a development environment outside of Docker, check out the [wiki](https://github.com/apoclyps/reviews/wiki/Development-Enviromnent).
+
+### Configuration
+
+Reviews supports both .ini and .env files. Reviews always searches for Options in this order:
+
+* Environment variables;
+* Repository: ini or .env file;
+* Configuration Path
+* Review Defaults
+
+#### Ini file
+Create a `settings.ini` next to your configuration module in the form:
+
+```bash
+[settings]
+REPOSITORY_CONFIGURATION=apoclyps/micropython-by-example
+Note: Since ConfigParser supports string interpolation, to represent the character % you need to escape it as %%.
+```
+
+#### Env file
+Create a `.env` text file on your repository's root directory in the form:
+
+```bash
+REPOSITORY_CONFIGURATION=apoclyps/micropython-by-example
+```
+
+#### Providing a configuration path
+
+If you wish to set the configuration path to use an `ini` or `.env` file when running the application, you can use the configuration of a specific file by supplying the path to the configuration like so:
+
+```bash
+export PATH_TO_CONFIG=/home/apoclyps/workspace/apoclyps
+```
+
+If at any time, you want to confirm your configuration reflects the file you have provided, you can use `reviews config` to view what current configuration of Reviews.
 
 ### Testing
 
-A test suite has been included to ensure Reviews functions correctly:.
+A test suite has been included to ensure Reviews functions correctly.
 
 To run the entire test suite with verbose output, run the following:
 

--- a/reviews/config/__init__.py
+++ b/reviews/config/__init__.py
@@ -6,6 +6,7 @@ from ..config.settings import (  # NOQA: F401
     GITHUB_URL,
     GITHUB_USER,
     LABEL_CONFIGURATION,
+    PATH_TO_CONFIG,
     REPOSITORY_CONFIGURATION,
     get_configuration,
     get_label_colour_map,

--- a/reviews/config/settings.py
+++ b/reviews/config/settings.py
@@ -17,6 +17,7 @@ GITHUB_URL = config("GITHUB_URL", cast=str, default="https://api.github.com")
 DEFAULT_PAGE_SIZE = config("DEFAULT_PAGE_SIZE", cast=int, default=100)
 
 # Application Config
+PATH_TO_CONFIG = config("PATH_TO_CONFIG", cast=str, default=None)
 DELAY_REFRESH = config("DELAY_REFRESH", cast=int, default=60)
 REPOSITORY_CONFIGURATION = config(
     "REPOSITORY_CONFIGURATION",

--- a/reviews/config/settings.py
+++ b/reviews/config/settings.py
@@ -1,7 +1,14 @@
+import os
 from typing import Dict, List, Tuple
 
-from decouple import Csv, config
+from decouple import AutoConfig, Csv
 from rich.color import ANSI_COLOR_NAMES
+
+# configures decouple to use settings.ini or .env file from another directory
+if path_to_config := os.environ.get("PATH_TO_CONFIG", None):
+    config = AutoConfig(search_path=path_to_config)
+else:
+    config = AutoConfig()
 
 # Github Config
 GITHUB_TOKEN = config("GITHUB_TOKEN", cast=str, default="")

--- a/reviews/tasks.py
+++ b/reviews/tasks.py
@@ -151,6 +151,7 @@ def render_config(show: bool) -> None:
         },
         {"name": "GITHUB_USER", "value": config.GITHUB_USER},
         {"name": "GITHUB_URL", "value": config.GITHUB_URL},
+        {"name": "PATH_TO_CONFIG", "value": f"{config.PATH_TO_CONFIG}"},
         {"name": "DEFAULT_PAGE_SIZE", "value": f"{config.DEFAULT_PAGE_SIZE}"},
         {"name": "DELAY_REFRESH", "value": f"{config.DELAY_REFRESH}"},
         {


### PR DESCRIPTION
### What's Changed

adds `PATH_TO_CONFIG` env var to provide configuration outside of module/repository and adds `PATH_TO_CONFIG` to config command:

![image](https://user-images.githubusercontent.com/1443700/120181350-d5f20d80-c204-11eb-8c4c-1f2847f9215d.png)


implements #115 

### Technical Description

Reads `PATH_TO_CONFIG ` from the environment if provided and configures decouple using `AutoConfig` with the `search_path` set to use `PATH_TO_CONFIG` as a value.

### Steps to reproduce

The following steps are used to test the configuration using `.env` and `.ini` files from within the module/repository (default location set by decouple) and a location specified by an env var.

```bash
# defaults to `apoclyps/reviews`
unset REPOSITORY_CONFIGURATION
```

![image](https://user-images.githubusercontent.com/1443700/120171397-ea7cd880-c1f9-11eb-9c78-f5ae355f4dd8.png)


#### Testing `.env` file within the repository

```bash
cd /home/apoclyps/workspace/apoclyps/reviews
touch .env
echo "REPOSITORY_CONFIGURATION=python/typeshed" >> .env
python -m reviews config
```

![image](https://user-images.githubusercontent.com/1443700/120170913-5dd21a80-c1f9-11eb-9c9c-c1cf7f973627.png)

```bash
rm .env
```

#### Testing `.ini` file within the repository

```bash
cd /home/apoclyps/workspace/apoclyps/reviews
touch settings.ini
echo "[settings]\nREPOSITORY_CONFIGURATION=python/typeshed" >> settings.ini
python -m reviews config
```

![image](https://user-images.githubusercontent.com/1443700/120171781-4e9f9c80-c1fa-11eb-827b-c911bf377207.png)

```bash
rm settings.ini
```

### Testing using `PATH_TO_CONFIG `


```bash
cd /home/apoclyps/
touch settings.ini
echo "[settings]\nREPOSITORY_CONFIGURATION=python/typeshed" >> settings.ini
cd /home/apoclyps/workspace/apoclyps/reviews
export PATH_TO_CONFIG=/home/apoclyps/
python -m reviews config
```

![image](https://user-images.githubusercontent.com/1443700/120181340-d38fb380-c204-11eb-89c7-72fb80ad40fc.png)
