### PR TITLE
[NO-TICKET] Implements error handling for repository not found

### DIFF
--- a/reviews/controller.py
+++ b/reviews/controller.py
@@ -4,7 +4,8 @@ from github.PullRequest import PullRequest as ghPullRequest
 from rich.table import Table
 
 from . import config
-from .layout import render_pull_request_table
+from .errors import RepositoryDoesNotExist
+from .layout import render_pull_request_table, render_repository_does_not_exist
 from .source_control import GithubAPI, Label, PullRequest
 
 
@@ -18,7 +19,15 @@ class PullRequestController:
         """Renders Terminal UI Dashboard"""
 
         title = f"{org}/{repository}"
-        pull_requests = self.update_pull_requests(org=org, repository=repository)
+        pull_requests = []
+        try:
+            pull_requests = self.update_pull_requests(org=org, repository=repository)
+        except RepositoryDoesNotExist:
+            return render_repository_does_not_exist(
+                title=f"{title} does not exist",
+                org=org,
+                repository=repository,
+            )
 
         if not pull_requests:
             return None

--- a/reviews/errors.py
+++ b/reviews/errors.py
@@ -1,0 +1,2 @@
+class RepositoryDoesNotExist(Exception):
+    """Unable to fetch the repository as it already exists"""

--- a/reviews/layout/__init__.py
+++ b/reviews/layout/__init__.py
@@ -4,5 +4,6 @@ from ..layout.helpers import (  # NOQA: F401
     generate_progress_tracker,
     generate_tree_layout,
     render_pull_request_table,
+    render_repository_does_not_exist,
 )
 from ..layout.managers import RenderLayoutManager  # NOQA: F401

--- a/reviews/layout/helpers.py
+++ b/reviews/layout/helpers.py
@@ -13,6 +13,30 @@ from ..config import get_label_colour_map
 from ..source_control import PullRequest
 
 
+def render_repository_does_not_exist(
+    title: str,
+    org: str,
+    repository: str,
+) -> Table:
+    """Renders a list of pull requests as a table"""
+    table = Table(show_header=True, header_style="bold white")
+    table.add_column("#", style="dim", width=7)
+    table.add_column(
+        f"[link=https://www.github.com/{org}/{repository}]{title}[/link]",
+        width=160,
+    )
+
+    table.add_row(
+        "",
+        (
+            "Please confirm this repository exists and that you can access it "
+            "before attempting to use it."
+        ),
+    )
+
+    return table
+
+
 def render_pull_request_table(
     title: str,
     pull_requests: List[PullRequest],

--- a/reviews/source_control/client.py
+++ b/reviews/source_control/client.py
@@ -1,10 +1,12 @@
 from typing import List
 
 from github import Github
+from github.GithubException import UnknownObjectException
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
 from .. import config
+from ..errors import RepositoryDoesNotExist
 
 
 class GithubAPI:
@@ -19,7 +21,10 @@ class GithubAPI:
 
     def get_repository(self, org: str, repo: str) -> Repository:
         """Returns a repository for a given organization."""
-        return self._client.get_repo(f"{org}/{repo}")
+        try:
+            return self._client.get_repo(f"{org}/{repo}")
+        except UnknownObjectException:
+            raise RepositoryDoesNotExist(f"{org}/{repo} does not exist")
 
     @staticmethod
     def _get_pull_requests(


### PR DESCRIPTION
### What's Changed

Implements error handling and a display within the UI to show when a repository does not exist or it cannot be accessed by the token provided.

### Technical Description

```bash
export REPOSITORY_CONFIGURATION="apoclyps/does-not-exist, apoclyps/micropython-by-example"
python -m reviews dashboard --no-reload
```

would have previously produced the following error causing `reviews` to crash

```bash
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/reference/repos#get-a-repository"}
```

![image](https://user-images.githubusercontent.com/1443700/120187965-6896aa80-c20d-11eb-85b6-c2ed967dabce.png)

now, the exception is caught and handled gracefully in the UI:

![image](https://user-images.githubusercontent.com/1443700/120187857-456bfb00-c20d-11eb-9593-f7572520007d.png)
