### PR TITLE
adds error handling for missing credentials

### DIFF
--- a/reviews/cli/main.py
+++ b/reviews/cli/main.py
@@ -1,6 +1,9 @@
 import click
+from rich.console import Console
 
 from ..commands import render, render_config, single_render
+from ..config import GITHUB_TOKEN
+from ..errors import InvalidGithubToken
 from ..version import __version__
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -40,13 +43,48 @@ def dashboard(reload: bool) -> None:
         reviews dashboard --reload \n
         reviews dashboard --no-reload \n
     """
+    console = Console()
+    style = "bold"
 
-    click.echo("loading dashboard")
+    github_token_msg = (
+        "> a valid GITHUB_TOKEN should be provided as an environmental "  # nosec
+        "variable or a value within a settings.ini or .env file. Please see "
+        "the project [link=https://github.com/apoclyps/reviews]"
+        "README[/link] for more methods on providing configuration."
+        "\n"
+    )
+    missing_github_token_msg = (
+        "\n[red]GITHUB_TOKEN[/] is required and has not been provided as "
+        "configuration needed to use Reviews. \n\n"
+        f"{github_token_msg}"
+    )
+    invalid_github_token_msg = (
+        "\n[red]GITHUB_TOKEN[/] is required configuration and an invalid "
+        "token has been supplied to Reviews. \n\n"
+        f"{github_token_msg}"
+    )
 
-    if reload:
-        render()
-    else:
-        single_render()
+    if not GITHUB_TOKEN:
+        console.print(
+            missing_github_token_msg,
+            style=style,
+        )
+        return
+
+    try:
+        click.echo("loading dashboard")
+
+        if reload:
+            render()
+        else:
+            single_render()
+    except InvalidGithubToken:
+        console.print(
+            invalid_github_token_msg,
+            style=style,
+        )
+
+    return
 
 
 def main() -> None:

--- a/reviews/errors.py
+++ b/reviews/errors.py
@@ -1,2 +1,6 @@
 class RepositoryDoesNotExist(Exception):
     """Unable to fetch the repository as it already exists"""
+
+
+class InvalidGithubToken(Exception):
+    """Unable to query Github using an empty or invalid Github Token"""

--- a/reviews/source_control/client.py
+++ b/reviews/source_control/client.py
@@ -1,12 +1,12 @@
 from typing import List
 
 from github import Github
-from github.GithubException import UnknownObjectException
+from github.GithubException import BadCredentialsException, UnknownObjectException
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
 from .. import config
-from ..errors import RepositoryDoesNotExist
+from ..errors import InvalidGithubToken, RepositoryDoesNotExist
 
 
 class GithubAPI:
@@ -25,6 +25,8 @@ class GithubAPI:
             return self._client.get_repo(f"{org}/{repo}")
         except UnknownObjectException:
             raise RepositoryDoesNotExist(f"{org}/{repo} does not exist")
+        except BadCredentialsException:
+            raise InvalidGithubToken("GITHUB_TOKEN is not valid.")
 
     @staticmethod
     def _get_pull_requests(


### PR DESCRIPTION
### What's Changed

Handle missing required configuration to avoid verbose stack traces for invalid/missing credentials.

![image](https://user-images.githubusercontent.com/1443700/120244345-dff62980-c261-11eb-850a-caef5e3cead7.png)

![image](https://user-images.githubusercontent.com/1443700/120244282-bd641080-c261-11eb-8e78-b79d9bfe8ffa.png)

implements fix for #151 

### Technical Description

Adds error handling and specifically checks if the `GITHUB_TOKEN` is configured prior to attempting to use it.

```bash
unset GITHUB_TOKEN
python -m reviews dashboard --no-reload
```

**before**

```bash
 apoclyps@shodan  ~/workspace/apoclyps/reviews   main  python -m reviews dashboard --no-reload
loading dashboard
Traceback (most recent call last):
  File "/home/apoclyps/.pyenv/versions/3.9.1/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/apoclyps/.pyenv/versions/3.9.1/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/apoclyps/workspace/apoclyps/reviews/reviews/__main__.py", line 6, in <module>
    main()
  File "/home/apoclyps/workspace/apoclyps/reviews/reviews/cli/main.py", line 54, in main
    cli()
  File "/home/apoclyps/.pyenv/versions/3.9.1/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/home/apoclyps/.pyenv/versions/3.9.1/lib/python3.9/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/home/apoclyps/.pyenv/versions/3.9.1/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/apoclyps/.pyenv/versions/3.9.1/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/apoclyps/.pyenv/versions/3.9.1/lib/python3.9/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/home/apoclyps/workspace/apoclyps/reviews/reviews/cli/main.py", line 49, in dashboard
    single_render()
  File "/home/apoclyps/workspace/apoclyps/reviews/reviews/commands.py", line 58, in single_render
    body = _render_pull_requests(controller=controller, configuration=configuration)
  File "/home/apoclyps/workspace/apoclyps/reviews/reviews/commands.py", line 39, in _render_pull_requests
    tables = [
  File "/home/apoclyps/workspace/apoclyps/reviews/reviews/commands.py", line 40, in <listcomp>
    controller.retrieve_pull_requests(org=org, repository=repo)
  File "/home/apoclyps/workspace/apoclyps/reviews/reviews/controller.py", line 24, in retrieve_pull_requests
    pull_requests = self.update_pull_requests(org=org, repository=repository)
  File "/home/apoclyps/workspace/apoclyps/reviews/reviews/controller.py", line 57, in update_pull_requests
    pull_requests = self.client.get_pull_requests(org=org, repo=repository)
  File "/home/apoclyps/workspace/apoclyps/reviews/reviews/source_control/client.py", line 39, in get_pull_requests
    repository = self.get_repository(org=org, repo=repo)
  File "/home/apoclyps/workspace/apoclyps/reviews/reviews/source_control/client.py", line 25, in get_repository
    return self._client.get_repo(f"{org}/{repo}")
  File "/home/apoclyps/.pyenv/versions/3.9.1/lib/python3.9/site-packages/github/MainClass.py", line 330, in get_repo
    headers, data = self.__requester.requestJsonAndCheck("GET", url)
  File "/home/apoclyps/.pyenv/versions/3.9.1/lib/python3.9/site-packages/github/Requester.py", line 353, in requestJsonAndCheck
    return self.__check(
  File "/home/apoclyps/.pyenv/versions/3.9.1/lib/python3.9/site-packages/github/Requester.py", line 378, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.BadCredentialsException: 401 {"message": "Bad credentials", "documentation_url": "https://docs.github.com/rest"}
```

**After**

```bash
python -m reviews dashboard --no-reload

GITHUB_TOKEN is required and has not been provided as configuration needed to use Reviews.

> a valid GITHUB_TOKEN should be provided as an environmental variable, or a value within a settings.ini or .env file. Please see the project README for more methods on providing configuration.
```