### PR TITLE
[NO-TICKET] adds metric command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ pip install --upgrade reviews
 
 reviews config --show
 
+reviews metrics
+
 reviews dashboard --no-reload
 ```
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ flake8-unused-arguments==0.0.6
 flake8==3.9.2
 freezegun==1.1.0
 isort==5.8.0
+ipdb==0.13.8
 mypy==0.812
 pre-commit==2.13.0
 pylint==2.8.3

--- a/reviews/cli/main.py
+++ b/reviews/cli/main.py
@@ -4,6 +4,7 @@ from rich.console import Console
 from ..commands import render, render_config, single_render
 from ..config import GITHUB_TOKEN
 from ..errors import InvalidGithubToken
+from ..metrics import repository_metrics
 from ..version import __version__
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -16,6 +17,15 @@ def cli() -> None:
 
     For feature requests or bug reports: https://github.com/apoclyps/reviews/issues
     """
+
+
+@cli.command(help="Show the activity metrics per repository")
+def metrics() -> None:
+    """
+    Command:\n
+        reviews metrics
+    """
+    repository_metrics()
 
 
 @cli.command(help="Show the current configuration used by Reviews")

--- a/reviews/metrics/__init__.py
+++ b/reviews/metrics/__init__.py
@@ -1,0 +1,1 @@
+from .controller import repository_metrics  # NOQA: F401

--- a/reviews/metrics/controller.py
+++ b/reviews/metrics/controller.py
@@ -1,0 +1,55 @@
+from typing import Optional
+
+import humanize
+from github.Repository import Repository
+from rich.console import Console
+from rich.table import Table
+
+from ..config import get_configuration
+from ..errors import RepositoryDoesNotExist
+from ..source_control import GithubAPI
+
+
+def repository_metrics() -> None:
+    """Renders an aggregated table view displaying contributors by contributors
+    for the lifetime of a repository.
+    """
+    console = Console()
+
+    for org, repo in get_configuration():
+        client = GithubAPI()
+        repository: Optional[Repository] = None
+        try:
+            repository = client.get_repository(org=org, repo=repo)
+        except RepositoryDoesNotExist:
+            continue
+
+        console.print()
+        table = Table(title=f"Repository Activity for {org}/{repo}")
+        table.add_column("User", no_wrap=True, width=25)
+        table.add_column("Additions", width=10)
+        table.add_column("Deletions", width=10)
+        table.add_column("Commits", width=10)
+
+        if repository:
+            for contributor in repository.get_stats_contributors():  # type: ignore
+                name = contributor.author.name
+                if not name:
+                    continue
+
+                additions = 0
+                deletions = 0
+                commits = 0
+                for week in contributor.weeks:
+                    additions += week.a
+                    deletions += week.d
+                    commits += week.c
+
+                additions = f"[green]+{humanize.intcomma(additions)}[/]"
+                deletions = f"[red]-{humanize.intcomma(deletions)}[/]"
+                commits = f"[white]{humanize.intcomma(commits)}[/]"
+
+                table.add_row(name, additions, deletions, commits)
+
+        console.print(table)
+        console.print()


### PR DESCRIPTION
### What's Changed

Adds a simple metric command to show aggregated contributor metrics to a list of repositories configured using `REVIEWS_REPOSITORY_CONFIGURATION`.

![image](https://user-images.githubusercontent.com/1443700/120388162-ac2f0880-c322-11eb-93a9-74bfa6ce59c2.png)

### Technical Description

adds a new `metrics` command to display an aggregated view of additions, deletions, commits by individual contributors over the lifetime of a repository. 

Uses the list of repositories configured by `REVIEWS_REPOSITORY_CONFIGURATION` to display a table for each repository.