### PR TITLE
[NO-TICKET] adds codespell to linting checks

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,8 @@
+[codespell]
+quiet-level = 3
+count =
+check-hidden =
+check-filenames =
+enable-colors =
+builtin = clear,rare,informal,code,names
+ignore-words-list = pullrequest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - name: Install libnotify
-        run: sudo apt-get install libnotify-bin
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -33,6 +31,7 @@ jobs:
           isort --check-only --diff .
           flake8 .
           pylint --rcfile=.pylintrc reviews
+          codespell reviews
       - name: Typecheck with mypy
         run: mypy reviews --ignore-missing-imports --disallow-untyped-defs
       - name: Test with pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
       - id: pretty-format-json
         args: ["--no-sort-keys", "--autofix"]
         files: ^tests/app/
+      - id: check-ast
 
   - repo: meta
     hooks:
@@ -110,3 +111,13 @@ repos:
         ]
         language: system
         types: [python]
+
+  -   repo: https://github.com/codespell-project/codespell
+      rev: v2.1.0
+      hooks:
+      -   id: codespell
+          name: codespell
+          description: Checks for common misspellings in text files.
+          entry: codespell reviews
+          language: python
+          types: [text]

--- a/.pylintrc
+++ b/.pylintrc
@@ -57,7 +57,7 @@ confidence=
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
 # file where it should appear only once). You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
+# disable everything first and then re-enable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ reviews dashboard --no-reload
 
 [![asciicast](https://asciinema.org/a/414444.svg)](https://asciinema.org/a/414444)
 
-### Addtional Support
+### Additional Support
 
 If you wish to use Reviews with a Github Enterprise instead of Github (https://api.github.com", you can set the `GITHUB_URL` with your custom hostname. You will also need to ensure your `GITHUB_USER` and `GITHUB_TOKEN` exist within your Enterprise Github instance:
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,14 +2,17 @@
 
 bandit==1.7.0
 black==21.6b0
+codespell==2.1.0
 flake8-unused-arguments==0.0.6
 flake8==3.9.2
 freezegun==1.1.0
-isort==5.8.0
 ipdb==0.13.9
+isort==5.8.0
 mypy==0.902
 pre-commit==2.13.0
 pylint==2.8.3
 pytest-cov==2.12.1
 pytest==6.2.4
+types-click==7.1.1
+types-freezegun==0.1.3
 vulture==2.3

--- a/reviews/config/helpers.py
+++ b/reviews/config/helpers.py
@@ -6,7 +6,7 @@ from .settings import REVIEWS_LABEL_CONFIGURATION, REVIEWS_REPOSITORY_CONFIGURAT
 
 
 def get_configuration() -> List[Tuple[str, str]]:
-    """converts a comma seperated list of organizations/repositories into a list
+    """converts a comma separated list of organizations/repositories into a list
     of tuples.
     """
 
@@ -20,7 +20,7 @@ def get_configuration() -> List[Tuple[str, str]]:
 
 
 def get_label_colour_map() -> Dict[str, str]:
-    """converts a comma seperated list of organizations/repositories into a list
+    """converts a comma separated list of organizations/repositories into a list
     of tuples.
     """
 


### PR DESCRIPTION
### What's Changed

Adds `codespell` to pre-commit and lining checks

### Technical Description

see: spell-project/codespell