### PR TITLE
adds pyupgrade to linting and pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
           flake8 .
           pylint --rcfile=.pylintrc reviews
           codespell reviews
+          find . -name '*.py' -exec pyupgrade {} +
       - name: Typecheck with mypy
         run: mypy reviews --ignore-missing-imports --disallow-untyped-defs
       - name: Test with pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,3 +121,8 @@ repos:
           entry: codespell reviews
           language: python
           types: [text]
+
+  -   repo: https://github.com/asottile/pyupgrade
+      rev: v2.19.4
+      hooks:
+      -   id: pyupgrade

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ build.lint: ## Build the lint container
 	@docker-compose build pylint
 	@docker-compose build bandit
 	@docker-compose build vulture
+	@docker-compose build codespell
+	@docker-compose build pyupgrade
+
 
 build.all: build.cli build.test build.lint  ## Build all containers
 
@@ -60,6 +63,8 @@ lint: ## lint and autocorrect the code
 	@docker-compose run --rm --no-deps pylint
 	@docker-compose run --rm --no-deps bandit
 	@docker-compose run --rm --no-deps vulture
+	@docker-compose run --rm --no-deps codespell
+	@docker-compose run --rm --no-deps pyupgrade
 
 
 install: ## build and install the cli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,14 @@ services:
     <<: *cli
     command: vulture --min-confidence 90 reviews
 
+  codespell:
+    <<: *cli
+    command: codespell reviews
+
+  pyupgrade:
+    <<: *cli
+    command: find . -name '*.py' -exec pyupgrade {} +
+
   test:
     <<: *cli
     environment:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,3 +16,4 @@ pytest==6.2.4
 types-click==7.1.2
 types-freezegun==0.1.4
 vulture==2.3
+pyupgrade==2.19.4


### PR DESCRIPTION
### What's Changed

adds pyupgrade to linting and pre-commit to detect and upgrade syntax automatically when upgrading python versions.

### Technical Description

see: https://github.com/asottile/pyupgrade and https://github.com/asottile/pyupgrade/issues/40 (for running pyupgrade across all python files)