### PR TITLE
[ISSUE-137] removes experimental support for github enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,6 @@ export REVIEWS_GITLAB_REPOSITORY_CONFIGURATION="27629846:apoclyps/reviews"
 reviews dashboard --provider=gitlab
 ```
 
-**Experimental**
-
-#### Github Enterprise
-
-The following features have been implemented but support is considered experimental and it may be removed in a future release.
-
-If you wish to use Reviews with a Github Enterprise instead of Github (https://api.github.com", you can set the `GITHUB_URL` with your custom hostname. You will also need to ensure your `GITHUB_USER` and `GITHUB_TOKEN` exist within your Enterprise Github instance:
-
-```bash
-export GITHUB_URL=https://{hostname}/api/v3
-export GITHUB_USER=user
-export GITHUB_TOKEN=token
-```
-
 ### Getting started with local development
 
 To build and run the CLI on your host, you will need Python 3.9, pip, and virtualenv to build and run `review`.


### PR DESCRIPTION
### What's Changed

removes experimental support for Github Enterprise

### Technical Description

There was no suitable way to test GitHub enterprise and support couldn't be confirmed, so this PR removes support until someone wishes to support it. 

closes [#193 ](https://github.com/apoclyps/reviews/issues/137)