### PR TITLE
allows faster execution by running tasks in parrallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash

--- a/reviews/controller.py
+++ b/reviews/controller.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import Dict, List, Tuple, Union
 
@@ -105,7 +106,9 @@ class GithubPullRequestController(PullRequestController):
     def render(self, configuration: List[Tuple[str, str]]) -> Panel:
         """Renders all pull requests for the provided configuration"""
 
-        tables = [self.retrieve_pull_requests(org=org, repository=repo) for (org, repo) in configuration]
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            arguments = ((org, repo) for (org, repo) in configuration)
+            tables = list(executor.map(lambda f: self.retrieve_pull_requests(*f), arguments))
 
         # filter unrenderable `None` results
         return Panel(


### PR DESCRIPTION
### What's Changed

allows faster execution by running tasks in parrallel

### Technical Description

uses a ThreadPoolExecutor to run up to 10 workers to retrieve results from Github to reduce the time taken to load results.

An incidental change is that this PR also adds python 3.10 and 3.11 to the matrix of supported python versions for testing