### PR TITLE
Fix .env search path

### DIFF
--- a/reviews/config/settings.py
+++ b/reviews/config/settings.py
@@ -6,7 +6,7 @@ from decouple import AutoConfig, Csv
 if REVIEWS_PATH_TO_CONFIG := os.environ.get("REVIEWS_PATH_TO_CONFIG", None):
     config = AutoConfig(search_path=REVIEWS_PATH_TO_CONFIG)
 else:
-    config = AutoConfig()
+    config = AutoConfig('.')
 
 # Layout Config
 REVIEWS_AUTHOR = config("REVIEWS_AUTHOR", cast=bool, default=True)

--- a/reviews/config/settings.py
+++ b/reviews/config/settings.py
@@ -6,7 +6,7 @@ from decouple import AutoConfig, Csv
 if REVIEWS_PATH_TO_CONFIG := os.environ.get("REVIEWS_PATH_TO_CONFIG", None):
     config = AutoConfig(search_path=REVIEWS_PATH_TO_CONFIG)
 else:
-    config = AutoConfig('.')
+    config = AutoConfig(search_path=".")
 
 # Layout Config
 REVIEWS_AUTHOR = config("REVIEWS_AUTHOR", cast=bool, default=True)


### PR DESCRIPTION
When `REVIEWS_PATH_TO_CONFIG` is not set, `decouple.AutoConfig()` would
search  for a `.env` file starting from the location of the reviews Python
source, which in most cases was not the appropriate search semantics.

By having `AutoConfig` start in the current directory (`'.'`), we will get
the behavior that most people probably expect.

Closes: #580
